### PR TITLE
詳細表示機能の実装

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,7 @@
 class ApplicationController < ActionController::Base
   before_action :basic_auth
   before_action :configure_permitted_parameters, if: :devise_controller?
-  before_action :authenticate_user!, except:[:index]
+  before_action :authenticate_user!, except:[:index,:show]
   private
 
   def basic_auth

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -18,6 +18,10 @@ class ItemsController < ApplicationController
       end 
   end
 
+  def show
+    @item=Item.find(params[:id])
+  end
+
   private
 
   def item_params

--- a/app/javascript/item_price.js
+++ b/app/javascript/item_price.js
@@ -4,9 +4,8 @@ window.addEventListener('load', () => {
     const inputValue=priceInput.value;
     fee=Math.floor(inputValue*0.1);
     profit=Math.floor(inputValue*0.9);
-    
     const addTax=document.getElementById("add-tax-price");
-   addTax.innerHTML=fee
+    addTax.innerHTML=fee
     const sailsProfit=document.getElementById("profit");
     sailsProfit.innerHTML=profit
   });

--- a/app/models/delivery_date.rb
+++ b/app/models/delivery_date.rb
@@ -1,4 +1,4 @@
-class Delivery < ActiveHash::Base
+class DeliveryDate < ActiveHash::Base
   self.data= [
   { id: 1, name: '---' },
   { id: 2, name: '１〜２日で発送' },

--- a/app/models/delivery_source.rb
+++ b/app/models/delivery_source.rb
@@ -1,4 +1,4 @@
-class Prefecture < ActiveHash::Base
+class DeliverySource < ActiveHash::Base
   self.data = [
     {id: 0, name: '---'}, {id: 1, name: '北海道'}, {id: 2, name: '青森県'}, 
     {id: 3, name: '岩手県'}, {id: 4, name: '宮城県'}, {id: 5, name: '秋田県'}, 

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -20,8 +20,8 @@ class Item < ApplicationRecord
   extend ActiveHash::Associations::ActiveRecordExtensions
     belongs_to_active_hash :genre
     belongs_to_active_hash :condition
-    belongs_to_active_hash :delivery
-    belongs_to_active_hash :shipping
-    belongs_to_active_hash :prefecture 
+    belongs_to_active_hash :delivery_date
+    belongs_to_active_hash :shipping_charges
+    belongs_to_active_hash :delivery_source
     
   end

--- a/app/models/shipping_charges.rb
+++ b/app/models/shipping_charges.rb
@@ -1,4 +1,4 @@
-class Shipping < ActiveHash::Base
+class ShippingCharges < ActiveHash::Base
   self.data = [
     { id: 1, name: '---' },
     { id: 2, name: '着払い（購入者負担）' },

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -162,23 +162,27 @@
 
       <%# 商品がない場合のダミー %>
       <%# 商品がある場合は表示されないようにしましょう %>
-      <li class='list'>
-        <%= link_to '#' do %>
-        <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            商品を出品してね！
-          </h3>
-          <div class='item-price'>
-            <span>99999999円<br>(税込み)</span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
+      <% unless @items %>
+        
+      
+        <li class='list'>
+          <%= link_to '#' do %>
+          <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
+          <div class='item-info'>
+            <h3 class='item-name'>
+              商品を出品してね！
+            </h3>
+            <div class='item-price'>
+              <span>99999999円<br>(税込み)</span>
+              <div class='star-btn'>
+                <%= image_tag "star.png", class:"star-icon" %>
+                <span class='star-count'>0</span>
+              </div>
             </div>
           </div>
-        </div>
-        <% end %>
-      </li>
+          <% end %>
+        </li>
+      <%end%>
       <%# //商品がある場合は表示されないようにしましょう %>
       <%# /商品がない場合のダミー %>
     </ul>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -131,7 +131,7 @@
       
         <% @items.each do |item| %>
       <li class='list'>
-        <%= link_to "#" do %>
+        <%= link_to item_path(item.id) do %>
           <div class='item-img-content'>
             
           <%= image_tag item.image,class:"item-img" %>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -71,17 +71,17 @@
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:shipping_charges_id, Shipping.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <%= f.collection_select(:shipping_charges_id, ShippingCharges.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:delivery_source_id, Prefecture.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
+        <%= f.collection_select(:delivery_source_id, DeliverySource.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:delivery_date_id, Delivery.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:delivery_date_id, DeliveryDate.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
     <%# /配送について %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,10 +4,10 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.name %>
     </h2>
     <div class='item-img-content'>
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
       <div class='sold-out'>
         <span>Sold Out!!</span>
@@ -23,47 +23,51 @@
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
-    <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
-    <p class='or-text'>or</p>
-    <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
-
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
+    
+  <%if user_signed_in?%> 
+    <% if current_user.id == @item.user_id %>
+      <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+      <p class='or-text'>or</p>
+      <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+    <% elsif current_user.id != @item.user_id%>
+    
+      <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+    <% end %>
+    
+    
+  <%end%>
 
 
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.text %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%=@item.user.nickname  %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.genre.name%></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.condition.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.shipping_charges.name%></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.delivery_source.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.delivery_date.name%></td>
         </tr>
       </tbody>
     </table>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -16,7 +16,7 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        <%=@item.price%>
       </span>
       <span class="item-postage">
         (税込) 送料込み
@@ -106,7 +106,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <a href="#" class='another-item'><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <a href="#" class='another-item'><%= @item.genre.name %>をもっと見る</a>
 </div>
 
 <%= render "shared/footer" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
  root to: "items#index"
- resources :items, only:[:index,:new,:create]
+ resources :items, only:[:index,:new,:create,:show]
 end

--- a/spec/models/delivery_spec.rb
+++ b/spec/models/delivery_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
 
-RSpec.describe Delivery, type: :model do
+RSpec.describe DeliveryDate, type: :model do
   pending "add some examples to (or delete) #{__FILE__}"
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Item, type: :model do
     context "出品できる時" do
       it "name,text,condition_id,shipping_charges_id,delivery_source_id,delivery_date_id,price,genre_id,が存在すれば出品できる" do
         expect(@item).to be_valid
+        
       end
       
       

--- a/spec/models/prefecture_spec.rb
+++ b/spec/models/prefecture_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
 
-RSpec.describe Prefecture, type: :model do
+RSpec.describe DeliverySource, type: :model do
   pending "add some examples to (or delete) #{__FILE__}"
 end

--- a/spec/models/shipping_spec.rb
+++ b/spec/models/shipping_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
 
-RSpec.describe Shipping, type: :model do
+RSpec.describe ShippingCharges, type: :model do
   pending "add some examples to (or delete) #{__FILE__}"
 end


### PR DESCRIPTION
What
どのユーザーでも商品詳細ページへの遷移ができるように実装しました。
詳細ページにおいて出品した際に入力した情報が表示されるように実装しました。
出品者本人には編集・削除が表示されるようにし、出品者以外のログインユーザーには購入表示ができるように実装しました。
未ログインユーザーにおいては、編集・削除・購入の表示がないように実装しました。
Why
どんなユーザーでも詳細ページへ遷移できるようにした事で、より細かい情報を知り本アプリケーションへの興味を持ってもらうことができると思われます。また新規顧客獲得にもつながると考えらます。
出品者本人には、編集・削除ができるようにすることで商品に不備があった場合に編集や削除ができるように実装しました。出品者本人が自分の商品を購入できないようにすることで無駄なアクセスや、不正防止ができると考えました。
他のログインユーザーや未ログインユーザーには編集・削除の表示をさせない事で不正に編集や削除がされないようにできると考えました。
未ログインユーザーには編集・削除・購入を非表示にする事で、DB管理や不正行為を未然に防ぐ事ができると考えました。

https://gyazo.com/8708e4a4b3f6acd179b99526dc302db7
https://gyazo.com/a7bf427154bafac3a2783a693ae02cf9
https://gyazo.com/feec08de5c1aa23ee84d5895eb8fbb42